### PR TITLE
Reformat find by name command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AbstractFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AbstractFindCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.ContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
-public class FindCommand extends Command {
+abstract public class AbstractFindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
@@ -22,7 +22,7 @@ public class FindCommand extends Command {
 
     private final ContainsKeywordsPredicate predicate;
 
-    public FindCommand(ContainsKeywordsPredicate predicate) {
+    public AbstractFindCommand(ContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 
@@ -41,11 +41,11 @@ public class FindCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof FindCommand)) {
+        if (!(other instanceof AbstractFindCommand)) {
             return false;
         }
 
-        FindCommand otherFindCommand = (FindCommand) other;
+        AbstractFindCommand otherFindCommand = (AbstractFindCommand) other;
         return this.predicate.equals(otherFindCommand.predicate);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AbstractFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AbstractFindCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.ContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
-abstract public class AbstractFindCommand extends Command {
+public abstract class AbstractFindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.ContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -15,44 +15,44 @@ abstract public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names, contacts or emails "
+            + "contain any of the specified keywords (case-insensitive) and displays them as a list with indices.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-//    private final NameContainsKeywordsPredicate predicate;
-//
-//    public FindCommand(NameContainsKeywordsPredicate predicate) {
-//        this.predicate = predicate;
-//    }
-//
-//    @Override
-    public CommandResult execute(Model model) {
-//        requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
-//        return new CommandResult(
-//                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
-//    }
+    private final ContainsKeywordsPredicate predicate;
 
-//    @Override
-//    public boolean equals(Object other) {
-//        if (other == this) {
-//            return true;
-//        }
-//
-//        // instanceof handles nulls
-//        if (!(other instanceof FindCommand)) {
-//            return false;
-//        }
-//
-//        FindCommand otherFindCommand = (FindCommand) other;
-//        return predicate.equals(otherFindCommand.predicate);
-//    }
-//
-//    @Override
-//    public String toString() {
-//        return new ToStringBuilder(this)
-//                .add("predicate", predicate)
-//                .toString();
-//    }
+    public FindCommand(ContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(this.predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FindCommand)) {
+            return false;
+        }
+
+        FindCommand otherFindCommand = (FindCommand) other;
+        return this.predicate.equals(otherFindCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", this.predicate)
+                .toString();
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.ContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -15,14 +15,14 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names, contacts or emails "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names "
             + "contain any of the specified keywords (case-insensitive) and displays them as a list with indices.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final ContainsKeywordsPredicate predicate;
+    private final NameContainsKeywordsPredicate predicate;
 
-    public FindCommand(ContainsKeywordsPredicate predicate) {
+    public FindCommand(NameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-public class FindCommand extends Command {
+abstract public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
@@ -20,39 +20,39 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
-
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
-        this.predicate = predicate;
-    }
-
-    @Override
+//    private final NameContainsKeywordsPredicate predicate;
+//
+//    public FindCommand(NameContainsKeywordsPredicate predicate) {
+//        this.predicate = predicate;
+//    }
+//
+//    @Override
     public CommandResult execute(Model model) {
-        requireNonNull(model);
+//        requireNonNull(model);
         model.updateFilteredPersonList(predicate);
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
-    }
+//        return new CommandResult(
+//                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+//    }
 
-    @Override
-    public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        // instanceof handles nulls
-        if (!(other instanceof FindCommand)) {
-            return false;
-        }
-
-        FindCommand otherFindCommand = (FindCommand) other;
-        return predicate.equals(otherFindCommand.predicate);
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .add("predicate", predicate)
-                .toString();
-    }
+//    @Override
+//    public boolean equals(Object other) {
+//        if (other == this) {
+//            return true;
+//        }
+//
+//        // instanceof handles nulls
+//        if (!(other instanceof FindCommand)) {
+//            return false;
+//        }
+//
+//        FindCommand otherFindCommand = (FindCommand) other;
+//        return predicate.equals(otherFindCommand.predicate);
+//    }
+//
+//    @Override
+//    public String toString() {
+//        return new ToStringBuilder(this)
+//                .add("predicate", predicate)
+//                .toString();
+//    }
 }

--- a/src/main/java/seedu/address/model/person/ContactContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ContactContainsKeywordsPredicate.java
@@ -9,16 +9,16 @@ import seedu.address.commons.util.ToStringBuilder;
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
+public class ContactContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
-         super(keywords);
+    public ContactContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
     }
 
     @Override
     public boolean test(Person person) {
         return this.getKeywords().stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
     }
 
     @Override
@@ -28,11 +28,11 @@ public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
+        if (!(other instanceof ContactContainsKeywordsPredicate)) {
             return false;
         }
 
-        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        ContactContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (ContactContainsKeywordsPredicate) other;
         return this.getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
     }
 

--- a/src/main/java/seedu/address/model/person/ContactContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ContactContainsKeywordsPredicate.java
@@ -1,7 +1,6 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;

--- a/src/main/java/seedu/address/model/person/ContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ContainsKeywordsPredicate.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
+abstract public class ContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public ContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    protected List<String> getKeywords() {
+        return this.keywords;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        ContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (ContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/ContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ContainsKeywordsPredicate.java
@@ -3,13 +3,12 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
-abstract public class ContainsKeywordsPredicate implements Predicate<Person> {
+public abstract class ContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
     public ContainsKeywordsPredicate(List<String> keywords) {

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,7 +1,6 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -9,16 +9,16 @@ import seedu.address.commons.util.ToStringBuilder;
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
+public class EmailContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
-         super(keywords);
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        super(keywords);
     }
 
     @Override
     public boolean test(Person person) {
-        return this.getKeywords().stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        return super.getKeywords().stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
     }
 
     @Override
@@ -28,11 +28,11 @@ public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
+        if (!(other instanceof EmailContainsKeywordsPredicate)) {
             return false;
         }
 
-        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        EmailContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (EmailContainsKeywordsPredicate) other;
         return this.getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
     }
 

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,7 +1,6 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
@@ -12,7 +11,7 @@ import seedu.address.commons.util.ToStringBuilder;
 public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
     public NameContainsKeywordsPredicate(List<String> keywords) {
-         super(keywords);
+        super(keywords);
     }
 
     @Override


### PR DESCRIPTION
Intermediate step for find sub-category implementation (find by name, contact, email)
* Create a temporary AbstractFindCommand class (to replace FindCommand later)
* Change ContainsKeywordPredicate hierachy (separate into Name-, Contact0 and Email-, all extending from ContainsKeywordPredicate abstract class)
* Other code format changes

Fixes #50 