### PR TITLE
Refactor add tag and delete tag command word

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -160,11 +160,11 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in CampusConnect.
 * `find n/Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
-### Deleting a person's tag : `deletetag`
+### Deleting a person's tag : `deltag`
 
 Deletes the specified person's tag.
 
-Format: `deletetag INDEX t/KEYWORD`
+Format: `deltag INDEX t/KEYWORD`
 
 * Deletes the tag with the specified name `KEYWORD` of the person at the specified `INDEX`.
 * The index refers to the index number shown in the displayed person list.
@@ -172,10 +172,10 @@ Format: `deletetag INDEX t/KEYWORD`
 * Only one tag can be deleted at a time.
 
 Examples:
-* `deletetag 1 t/friend` deletes the friend tag of the first person in the list.
+* `deltag 1 t/friend` deletes the friend tag of the first person in the list.
 
 Disallowed examples:
-* `deletetag 2 t/classmate t/neighbour` will not succeed as it tries to delete 2 tags at once.
+* `deltag 2 t/classmate t/neighbour` will not succeed as it tries to delete 2 tags at once.
 
 ### Undo a command : `undo`
 
@@ -253,7 +253,7 @@ Action     | Format, Examples
 **Find by email**   | `find e/KEYWORD [MORE_KEYWORDS]`<br> e.g., `find e/bigman123@email.com bobbyrick@example.com`
 **Find by phone number**   | `find p/KEYWORD [MORE_KEYWORDS]`<br> e.g., `find p/91234657 85432789`
 **Find by tag**   | `find t/KEYWORD [MORE_KEYWORDS]`<br> e.g., `find t/friend roommate`
-**Delete tag** | `deletetag INDEX t/KEYWORD` <br> e.g. `deletetag 1 t/friend`
+**Delete tag** | `deltag INDEX t/KEYWORD` <br> e.g. `deltag 1 t/friend`
 **Undo action** | `undo`
 **Redo action** | `redo`
 **List**   | `list`

--- a/docs/diagrams/AddTagSequenceDiagram.puml
+++ b/docs/diagrams/AddTagSequenceDiagram.puml
@@ -11,10 +11,10 @@ participant "r:CommandResult" as CommandResult LOGIC_COLOR
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-[-> LogicManager : execute("addTag 2 t/mate")
+[-> LogicManager : execute("addtag 2 t/mate")
 activate LogicManager
 
-LogicManager -> CampusConnectParser : parseCommand("addTag 2 t/mate")
+LogicManager -> CampusConnectParser : parseCommand("addtag 2 t/mate")
 activate CampusConnectParser
 
 create AddTagCommandParser

--- a/docs/diagrams/DeleteTagSequenceDiagram.puml
+++ b/docs/diagrams/DeleteTagSequenceDiagram.puml
@@ -14,10 +14,10 @@ box Model MODEL_COLOR_T1
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-[-> LogicManager : execute("deletetag 1 t/test")
+[-> LogicManager : execute("deltag 1 t/test")
 activate LogicManager
 
-LogicManager -> CampusConnectParser : parseCommand("deletetag 1 t/test")
+LogicManager -> CampusConnectParser : parseCommand("deltag 1 t/test")
 activate CampusConnectParser
 
 create DeleteTagCommandParser

--- a/src/main/java/seedu/address/logic/commands/AddTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTagCommand.java
@@ -18,7 +18,7 @@ import seedu.address.model.tag.Tag;
  * Add new tag(s) for an existing person
  */
 public class AddTagCommand extends Command {
-    public static final String COMMAND_WORD = "addTag";
+    public static final String COMMAND_WORD = "addtag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + "Add tag(s) for the person identified "
             + "by the index number used in the displayed person list "

--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -13,10 +13,10 @@ import seedu.address.model.tag.Tag;
 
 /**
  * Implements command to delete a tag from a person
- * format: deletetag [INDEX] t/[TAG NAME]
+ * format: deltag [INDEX] t/[TAG NAME]
  */
 public class DeleteTagCommand extends Command {
-    public static final String COMMAND_WORD = "deletetag";
+    public static final String COMMAND_WORD = "deltag";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes tag from the person identified by the index number used in the displayed person list.\n"


### PR DESCRIPTION
This should change:
- `addTag` to `addtag`
- `deletetag` to `deltag`

UML diagrams and user guide reflect this change as well.

Fixes #169 