### PR TITLE
Implement categorize tag command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
+
+
+/**
+ * Implements command to categorize all occurrences of a tag.
+ * Format: cattag t/TAG CATEGORY
+ */
+public class CategorizeTagCommand extends Command {
+
+    public static final String COMMAND_WORD = "cattag";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ":Categorizes a tag. Changes all occurrences of the specified tag to the desired category."
+            + "Parameters: " + PREFIX_TAG + "TAG (existing tag label) CATEGORY"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "CS1101S module";
+
+    public static final String MESSAGE_CAT_TAG_SUCCESS = "Category of tag %1$s has been changed successfully.";
+    public static final String MESSAGE_TAG_NOT_EXIST = "Tag not found: %1$s";
+    public static final String MESSAGE_INVALID_CATEGORY = "Invalid category: %1$s";
+
+    private final Tag targetTag;
+    private final TagCategory updatedCategory;
+
+    /**
+     * Constructs a command to categorize a tag.
+     */
+    public CategorizeTagCommand(Tag targetTag, TagCategory updatedCategory) {
+        requireNonNull(targetTag);
+        requireNonNull(updatedCategory);
+        this.targetTag = targetTag;
+        this.updatedCategory = updatedCategory;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        assert model != null;
+        if (!model.containsTag(targetTag)) {
+            throw new CommandException(String.format(MESSAGE_TAG_NOT_EXIST, targetTag));
+        }
+        model.setTagsCategory(targetTag, updatedCategory);
+        return new CommandResult(String.format(MESSAGE_CAT_TAG_SUCCESS, targetTag));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CampusConnectParser.java
+++ b/src/main/java/seedu/address/logic/parser/CampusConnectParser.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddTagCommand;
+import seedu.address.logic.commands.CategorizeTagCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -87,11 +88,15 @@ public class CampusConnectParser {
         case DeleteTagCommand.COMMAND_WORD:
             return new DeleteTagCommandParser().parse(arguments);
 
+        case CategorizeTagCommand.COMMAND_WORD:
+            return new CategorizeTagCommandParser().parse(arguments);
+
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();
 
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
+
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CategorizeTagCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CategorizeTagCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Optional;
+
+import seedu.address.logic.commands.CategorizeTagCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
+
+/**
+ * Parse input arguments and returns a new CategorizeTagCommand object.
+ */
+public class CategorizeTagCommandParser implements Parser<CategorizeTagCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CategorizeTagCommand
+     * and returns an CategorizeTagCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CategorizeTagCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TAG);
+        Optional<String> parsedArgs = argMultimap.getValue(PREFIX_TAG);
+        if (parsedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CategorizeTagCommand.MESSAGE_USAGE));
+        }
+        String[] split = parsedArgs.get().split("\\s+", 2);
+        Tag tag = ParserUtil.parseTag(split[0]);
+        TagCategory cat = parseCategory(split[1]);
+        return new CategorizeTagCommand(tag, cat);
+    }
+
+    private TagCategory parseCategory(String cat) throws ParseException {
+        switch (cat) {
+        case "general":
+            return TagCategory.GENERAL;
+        case "acads":
+            return TagCategory.ACADEMICS;
+        case "activity":
+            return TagCategory.ACTIVITIES;
+        case "networking":
+            return TagCategory.NETWORKING;
+        case "mentor":
+            return TagCategory.MENTORSHIP;
+        default:
+            throw new ParseException(String.format(CategorizeTagCommand.MESSAGE_INVALID_CATEGORY, cat));
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/CampusConnect.java
+++ b/src/main/java/seedu/address/model/CampusConnect.java
@@ -13,6 +13,7 @@ import seedu.address.model.exceptions.UndoException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
 
 /**
  * Wraps all data at the CampusConnect level
@@ -168,6 +169,10 @@ public class CampusConnect implements ReadOnlyCampusConnect {
     @Override
     public ObservableList<Tag> getTagList() {
         return persons.asTagList();
+    }
+
+    public void setTagCategory(Tag t, TagCategory cat) {
+        persons.updateTagCategory(t, cat);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -109,7 +109,10 @@ public interface Model {
      */
     boolean containsTag(Tag tag);
 
-    public void setTagsCategory(Tag t, TagCategory cat);
+    /**
+     * Sets {@code TagCategory cat} to be the category of {@code Tag t}.
+     */
+    void setTagsCategory(Tag t, TagCategory cat);
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -9,6 +9,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
 
 /**
  * The API of the Model component.
@@ -102,6 +103,13 @@ public interface Model {
      * Returns a list of tags currently defined in CampusConnect
      */
     ObservableList<Tag> getListOfCurrentTags();
+
+    /**
+     * Returns true if the specified {@code Tag} exists in CampusConnect
+     */
+    boolean containsTag(Tag tag);
+
+    public void setTagsCategory(Tag t, TagCategory cat);
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -166,6 +167,19 @@ public class ModelManager implements Model {
     @Override
     public ObservableList<Tag> getListOfCurrentTags() {
         return FXCollections.unmodifiableObservableList(currentlyDefinedTags);
+    }
+
+    @Override
+    public boolean containsTag(Tag t) {
+        requireAllNonNull(t);
+        return currentlyDefinedTags.contains(t);
+    }
+
+    @Override
+    public void setTagsCategory(Tag t, TagCategory cat) {
+        requireAllNonNull(t, cat);
+        campusConnect.setTagCategory(t, cat);
+        refreshTagList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -13,6 +13,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -147,6 +148,29 @@ public class UniquePersonList implements Iterable<Person> {
             tagSet.addAll(person.getTags());
         }
         return FXCollections.observableArrayList(tagSet);
+    }
+
+    /**
+     * Update the category of all occurrences of a {@code Tag}
+     * @param t {@code Tag} to be updated
+     * @param cat updated {@code TagCategory}
+     */
+    public void updateTagCategory(Tag t, TagCategory cat) {
+        t.setTagCategory(cat);
+        for (Person person : internalList) {
+            Set<Tag> tagSet = person.getTags();
+            if (tagSet.contains(t)) {
+                replacePersonTag(person, t, cat);
+            }
+        }
+    }
+
+    private void replacePersonTag(Person p, Tag t, TagCategory cat) {
+        Set<Tag> tagsToReplace = new HashSet<>();
+        tagsToReplace.add(new Tag(t.tagName, cat));
+        Person replace = p.removeTag(t);
+        replace = replace.addTag(tagsToReplace);
+        setPerson(p, replace);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -23,6 +23,16 @@ public class Tag {
      * @param tagName A valid tag name.
      */
     public Tag(String tagName) {
+        this(tagName, TagCategory.GENERAL);
+    }
+
+    /**
+     * Constructs a {@code Tag}.
+     *
+     * @param tagName A valid tag name.
+     * @param category A valid {@code TagCategory}.
+     */
+    public Tag(String tagName, TagCategory category) {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.ReadOnlyCampusConnect;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagCategory;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -191,6 +192,16 @@ public class AddCommandTest {
         }
         @Override
         public void addPersonTags(Person p, Set<? extends Tag> tags) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public boolean containsTag(Tag tag) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public void setTagsCategory(Tag t, TagCategory cat) {
             throw new AssertionError("This method should not be called");
         }
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -109,6 +109,24 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void containsTag_tagInCampusConnect_returnsTrue() {
+        Tag tag = new Tag("friends");
+        modelManager.addPerson(new PersonBuilder().withTags("friends").build());
+        assertTrue(modelManager.containsTag(tag));
+    }
+
+    @Test
+    public void containsTag_tagNotInCampusConnect_returnsFalse() {
+        Tag tag = new Tag("non-existent-tag");
+        assertFalse(modelManager.containsTag(tag));
+    }
+
+    @Test
+    public void containsTag_nullTag_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.containsTag(null));
+    }
+
+    @Test
     public void equals() {
         CampusConnect campusConnect = new CampusConnectBuilder().withPerson(ALICE).withPerson(BENSON).build();
         CampusConnect differentCampusConnect = new CampusConnect();


### PR DESCRIPTION
This should:
- Create a new command `cattag`
- Categorize all occurrences of a tag if the category specified is valid

Known issues:
- Setting the category of a tag to its current category will save a CampusConnect version. (Same issue as `addtag`)

Will add more testcases.