### PR TITLE
Implement tag manager

### DIFF
--- a/src/main/java/seedu/address/model/CampusConnect.java
+++ b/src/main/java/seedu/address/model/CampusConnect.java
@@ -148,7 +148,7 @@ public class CampusConnect implements ReadOnlyCampusConnect {
     /**
      * Adds a new Tag to person
      */
-    public void addPersonTags(Person p, Set<? extends Tag> tagList) {
+    public void addPersonTags(Person p, Set<Tag> tagList) {
         persons.addPersonTags(p, tagList);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -76,7 +76,7 @@ public interface Model {
     /**
      * Adds a set of tag to person
      */
-    void addPersonTags(Person p, Set<? extends Tag>t);
+    void addPersonTags(Person p, Set<Tag>t);
 
     /**
      * Adds the given person.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -116,7 +116,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void addPersonTags(Person p, Set<? extends Tag> t) {
+    public void addPersonTags(Person p, Set<Tag> t) {
         campusConnect.addPersonTags(p, t);
         refreshTagList();
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -128,6 +128,13 @@ public class Person {
     }
 
     /**
+     * Overwrites the person's tag set.
+     */
+    public Person setAllTags(Set<Tag> tagSet) {
+        return new Person(this.name, this.phone, this.email, tagSet);
+    }
+
+    /**
      * Returns true if person contain any tag in the new tag set.
      */
     public boolean containsDuplicateTag(Set<? extends Tag> tagSet) {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -14,6 +15,7 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.tag.TagCategory;
+import seedu.address.model.tag.TagManager;
 
 /**
  * A list of persons that enforces uniqueness between its elements and does not allow nulls.
@@ -31,6 +33,7 @@ public class UniquePersonList implements Iterable<Person> {
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
     private final ObservableList<Person> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+    private final TagManager tagManager = new TagManager();
 
     /**
      * Returns true if the list contains an equivalent person as the given argument.
@@ -49,6 +52,8 @@ public class UniquePersonList implements Iterable<Person> {
         if (contains(toAdd)) {
             throw new DuplicatePersonException();
         }
+        Set<Tag> trackedTags = addTagsToManager(toAdd.getTags());
+        toAdd = toAdd.setAllTags(trackedTags);
         internalList.add(toAdd);
     }
 
@@ -61,9 +66,23 @@ public class UniquePersonList implements Iterable<Person> {
         if (contains(toAdd)) {
             throw new DuplicatePersonException();
         }
+        Set<Tag> trackedTags = addTagsToManager(toAdd.getTags());
+        toAdd = toAdd.setAllTags(trackedTags);
         internalList.add(ind, toAdd);
     }
 
+    /**
+     * Adds tags to the tagManager to be tracked.
+     * Returns a set of tracked tag objects.
+     */
+    private Set<Tag> addTagsToManager(Set<Tag> tagSet) {
+        Set<Tag> deduplicatedTags = new HashSet<>();
+        for (Tag tag : tagSet) {
+            Tag trackedTag = tagManager.getOrCreateTag(tag.tagName);
+            deduplicatedTags.add(trackedTag);
+        }
+        return deduplicatedTags;
+    }
 
     /**
      * Replaces the person {@code target} in the list with {@code editedPerson}.
@@ -81,6 +100,9 @@ public class UniquePersonList implements Iterable<Person> {
         if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
             throw new DuplicatePersonException();
         }
+        tagManager.removeTagOccurrence(target.getTags());
+        Set<Tag> trackedTags = addTagsToManager(editedPerson.getTags());
+        editedPerson = editedPerson.setAllTags(trackedTags);
 
         internalList.set(index, editedPerson);
     }
@@ -94,6 +116,7 @@ public class UniquePersonList implements Iterable<Person> {
         if (!internalList.remove(toRemove)) {
             throw new PersonNotFoundException();
         }
+        tagManager.removeTagOccurrence(toRemove.getTags());
     }
 
     public void setPersons(UniquePersonList replacement) {
@@ -110,7 +133,12 @@ public class UniquePersonList implements Iterable<Person> {
         if (!personsAreUnique(persons)) {
             throw new DuplicatePersonException();
         }
-
+        tagManager.clearAllTags();
+        List<Person> newPersons = new ArrayList<>();
+        for (Person p : persons) {
+            Set<Tag> trackedTags = tagManager.getOrCreateTag(p.getTags());
+            newPersons.add(p.setAllTags(trackedTags));
+        }
         internalList.setAll(persons);
     }
 
@@ -119,17 +147,32 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public void deletePersonTag(Person p, Tag t) {
         requireNonNull(p);
+        System.out.println("here" + t);
         Person replace = p.removeTag(t);
+        // NOTE: no need to remove tag from tagManager here, setPerson takes care of it.
         setPerson(p, replace);
     }
 
     /**
      * Adds a set of tag to a person.
      */
-    public void addPersonTags(Person p, Set<? extends Tag> t) {
+    public void addPersonTags(Person p, Set<Tag> t) {
         requireNonNull(p);
-        Person replace = p.addTag(t);
+        // remove tags already added to p
+        Set<Tag> uniqueTags = filterUniqueTags(p.getTags(), t);
+        Set<Tag> trackedTags = tagManager.getOrCreateTag(uniqueTags);
+        Person replace = p.addTag(trackedTags);
         setPerson(p, replace);
+    }
+
+    private Set<Tag> filterUniqueTags(Set<Tag> fixed, Set<Tag> toFilter) {
+        Set<Tag> uniqueTags = new HashSet<>();
+        for (Tag t : toFilter) {
+            if (!fixed.contains(t)) {
+                uniqueTags.add(t);
+            }
+        }
+        return uniqueTags;
     }
 
     /**
@@ -143,11 +186,7 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns the tag list of the Persons recorded
      */
     public ObservableList<Tag> asTagList() {
-        Set<Tag> tagSet = new HashSet<>();
-        for (Person person : internalList) {
-            tagSet.addAll(person.getTags());
-        }
-        return FXCollections.observableArrayList(tagSet);
+        return FXCollections.observableArrayList(tagManager.asTagList());
     }
 
     /**
@@ -156,21 +195,7 @@ public class UniquePersonList implements Iterable<Person> {
      * @param cat updated {@code TagCategory}
      */
     public void updateTagCategory(Tag t, TagCategory cat) {
-        t.setTagCategory(cat);
-        for (Person person : internalList) {
-            Set<Tag> tagSet = person.getTags();
-            if (tagSet.contains(t)) {
-                replacePersonTag(person, t, cat);
-            }
-        }
-    }
-
-    private void replacePersonTag(Person p, Tag t, TagCategory cat) {
-        Set<Tag> tagsToReplace = new HashSet<>();
-        tagsToReplace.add(new Tag(t.tagName, cat));
-        Person replace = p.removeTag(t);
-        replace = replace.addTag(tagsToReplace);
-        setPerson(p, replace);
+        tagManager.setTagCategory(t.tagName, cat);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -15,6 +15,7 @@ public class Tag {
 
     public final String tagName;
     private TagCategory tagCategory;
+    private int occurrences = 0;
 
     /**
      * Constructs a {@code Tag}.
@@ -36,7 +37,7 @@ public class Tag {
         requireNonNull(tagName);
         checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
         this.tagName = tagName;
-        this.tagCategory = TagCategory.GENERAL;
+        this.tagCategory = category;
     }
 
     /**
@@ -70,7 +71,23 @@ public class Tag {
         return this.tagCategory.getColorCode();
     }
 
+    public int getOccurrences() {
+        return occurrences;
+    }
 
+    /**
+     * Tncrease the recorded occurrences by 1.
+     */
+    public void incrementOccurrences() {
+        occurrences = occurrences + 1;
+    }
+
+    /**
+     * Decrease the recorded occurrences by 1.
+     */
+    public void decrementOccurrences() {
+        occurrences = occurrences - 1;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/tag/TagManager.java
+++ b/src/main/java/seedu/address/model/tag/TagManager.java
@@ -1,0 +1,128 @@
+package seedu.address.model.tag;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The manager of all the tags currently being used.
+ */
+public class TagManager {
+
+    private final HashMap<String, Tag> tagMap;
+
+    /**
+     * Constructs a new TagManager to track Tag usages.
+     */
+    public TagManager() {
+        this.tagMap = new HashMap<>();
+    }
+
+    /**
+     * Returns true if the Tag is being tracked in the TagManager.
+     */
+    public boolean containsTag(Tag t) {
+        String tagName = t.tagName;
+        return tagMap.containsKey(tagName);
+    }
+
+    /**
+     * Returns the Tag with the corresponding tag name.
+     * If the tag already exists, return the stored tag object.
+     * Else if the tag does not yet exist, create a new tag and return it. <br>
+     * <strong>Warning:</strong> only use this method if you want to add or increase tag tracking.
+     * @param tagName String of the tag name
+     * @return The new or existing tag with the corresponding tag name
+     */
+    public Tag getOrCreateTag(String tagName) {
+
+        Tag tagToIncrement = tagMap.computeIfAbsent(tagName, Tag::new);
+        System.out.println("tracking " + tagToIncrement.tagName + "(" + tagToIncrement.getTagCategory() + ")");
+        tagToIncrement.incrementOccurrences();
+        // System.out.println(tagToIncrement.usages);
+        System.out.println(tagMap.values());
+        return tagToIncrement;
+    }
+
+    /**
+     * Returns a set of tags that are being tracked by TagManager, corresponding to the input set.
+     */
+    public Set<Tag> getOrCreateTag(Set<Tag> tags) {
+        Set<Tag> trackedSet = new HashSet<>();
+        for (Tag t : tags) {
+            String tagName = t.tagName;
+            trackedSet.add(getOrCreateTag(tagName));
+        }
+        return trackedSet;
+    }
+
+    /**
+     * Reduces the usage count of the tag and removes it if no more occurrences remain.
+     */
+    public void removeTagOccurrence(Tag t) {
+        String tagName = t.tagName;
+        Tag tagToDecrement = tagMap.get(tagName);
+        assert tagToDecrement != null;
+        System.out.println("huh" + tagToDecrement);
+        if (tagToDecrement.getOccurrences() <= 1) {
+            System.out.println("removed");
+            tagMap.remove(tagToDecrement.tagName);
+            return;
+        }
+        tagToDecrement.decrementOccurrences();
+    }
+
+    /**
+     * Reduces the usage count of each tag in the given set and removes it if no more occurrences remain.
+     */
+    public void removeTagOccurrence(Set<Tag> tags) {
+        for (Tag t : tags) {
+            removeTagOccurrence(t);
+        }
+    }
+
+    /**
+     * Returns the stored category of the tag with same label as the passed {@code Tag t}.
+     */
+    public TagCategory getTagCategory(Tag t) {
+        String tagName = t.tagName;
+        return tagMap.get(tagName).getTagCategory();
+    }
+
+    /**
+     * Set the category of a tag.
+     * Assumes that the tag already exists in the TagManager.
+     */
+    public void setTagCategory(String tagName, TagCategory cat) {
+        System.out.println(cat);
+        Tag tag = tagMap.get(tagName);
+        tag.setTagCategory(cat);
+        System.out.println(tagMap.get(tagName).getTagCategory());
+    }
+
+    /**
+     * Clears the TagManager of all stored tags to an empty state.
+     */
+    public void clearAllTags() {
+        tagMap.clear();
+    }
+
+    /**
+     * Remove all the tags from the passed set, regardless of how many occurrences remain.
+     * @see TagManager#removeTagOccurrence(Set) removeTagOccurrence
+     */
+    public void removeTags(Set<Tag> tagSet) {
+        for (Tag t : tagSet) {
+            tagMap.remove(t.tagName);
+        }
+    }
+
+    /**
+     * Returns the existing tags as a Collection.
+     */
+    public Collection<Tag> asTagList() {
+        return tagMap.values();
+    }
+
+}

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -51,7 +51,9 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                // Tag category displayed for visual testing
+                // TODO: remove tag category text display after implementing colour code
+                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName + " " + tag.getTagCategory())));
 
         // add horizontal and vertical gaps for the tags FlowPane
         tags.setHgap(5);

--- a/src/main/java/seedu/address/ui/TagCard.java
+++ b/src/main/java/seedu/address/ui/TagCard.java
@@ -26,6 +26,8 @@ public class TagCard extends UiPart<Region> {
     public TagCard(Tag tag, int displayedIndex) {
         super(FXML);
         this.tag = tag;
-        tagName.setText((displayedIndex + 1) + ". " + tag.tagName);
+        // Tag category displayed for visual testing
+        // TODO: remove tag category text display after implementing colour code
+        tagName.setText((displayedIndex + 1) + ". " + tag.tagName + "(" + tag.getTagCategory() + ")");
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -191,7 +191,7 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called");
         }
         @Override
-        public void addPersonTags(Person p, Set<? extends Tag> tags) {
+        public void addPersonTags(Person p, Set<Tag> tags) {
             throw new AssertionError("This method should not be called");
         }
 


### PR DESCRIPTION
This should:
- Add a tag manager to store global instances of tags
- Each active person should now reference a tag instance in the tag manager, instead of their own copy of a tag
- Enable tag category to be edited across all persons, since they reference the same tag in the manager

Known issues:
- Person list in UI does not reflect changes to tag category immediately (only the tag list updates)
- Setting a tag to its existing category should raise an error

Closes #176 