### PR TITLE
Replace the invalid category example of "modules" with "acads"

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
@@ -20,7 +20,7 @@ public class CategorizeTagCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ":Categorizes a tag. Changes all occurrences of the specified tag to the desired category."
             + "Parameters: " + PREFIX_TAG + "TAG (existing tag label) CATEGORY"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "CS1101S module";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_TAG + "CS1101S acads";
 
     public static final String MESSAGE_CAT_TAG_SUCCESS = "Category of tag %1$s has been changed successfully.";
     public static final String MESSAGE_TAG_NOT_EXIST = "Tag not found: %1$s";


### PR DESCRIPTION
Closes #186 