### PR TITLE
Fix cattag not updating person list in the UI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
@@ -51,6 +51,7 @@ public class CategorizeTagCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_CATEGORY, targetTag, updatedCategory));
         }
         model.setTagsCategory(targetTag, updatedCategory);
+        model.refreshCampusConnect();
         return new CommandResult(String.format(MESSAGE_CAT_TAG_SUCCESS, targetTag));
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -57,6 +57,11 @@ public interface Model {
     ReadOnlyCampusConnect getCampusConnect();
 
     /**
+     * Refreshes the current data in CampusConnect.
+     */
+    void refreshCampusConnect();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -98,6 +98,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void refreshCampusConnect() {
+        this.setCampusConnect(campusConnect);
+    }
+
+    @Override
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return campusConnect.hasPerson(person);

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -137,6 +137,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void refreshCampusConnect() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
This should:
- Force `campusConnect` to refresh with the updated tags in the displayed person list

Fixes #203, fixes #204, fixes #207

