### PR TITLE
Fix cattag duplicate tag within command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -81,18 +81,18 @@ any traditional point-and-click management app.
 
 Action     | Format, Examples
 :--------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------:
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL [t/TAG]…​` <br> e.g., `add n/James Ho p/91231234 e/jamesho@example.com t/friend t/classmate`
-**Clear**  | `clear`
-**Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Find by contact information**   | `find PREFIX/KEYWORD [PREFIX/MORE_KEYWORDS]…​`<br> e.g., `find n/James t/floorball`   
-**Delete tag** | `deltag INDEX t/KEYWORD` <br> e.g. `deltag 1 t/friend`
-**Add tag** | `addtag INDEX t/KEYWORD [t/MORE_TAGS]…​` <br> e.g. `addtag 1 t/friend t/classmate`
-**Categorize tag** | `cattag t/TAG [t/MORE_TAGS…​] CATEGORY` <br> e.g. `cattag t/floorball t/mahjong activity`
-**Undo action** | `undo`
-**Redo action** | `redo`
-**List**   | `list`
-**Help**   | `help`
+**[Add](#adding-a-person-add)**    | `add n/NAME p/PHONE_NUMBER e/EMAIL [t/TAG]…​` <br> e.g., `add n/James Ho p/91231234 e/jamesho@example.com t/friend t/classmate`
+**[Clear](#clearing-all-entries--clear)**  | `clear`
+**[Delete](#deleting-a-person--delete)** | `delete INDEX`<br> e.g., `delete 3`
+**[Edit](#editing-a-person--edit)**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**[Find by contact information](#locating-persons-by-contact-information-find)**   | `find PREFIX/KEYWORD [PREFIX/MORE_KEYWORDS]…​`<br> e.g., `find n/James t/floorball`   
+**[Delete tag](#deleting-a-persons-tag--deltag)** | `deltag INDEX t/KEYWORD` <br> e.g. `deltag 1 t/friend`
+**[Add tag](#adds-tags-to-a-specific-person--addtag)** | `addtag INDEX t/KEYWORD [t/MORE_TAGS]…​` <br> e.g. `addtag 1 t/friend t/classmate`
+**[Categorize tag](#categorizing-a-tag--cattag)** | `cattag t/TAG [t/MORE_TAGS…​] CATEGORY` <br> e.g. `cattag t/floorball t/mahjong activity`
+**[Undo action](#undo-a-command--undo)** | `undo`
+**[Redo action](#redo-a-command-redo)** | `redo`
+**[List](#listing-all-persons--list)**   | `list`
+**[Help](#viewing-help--help)**   | `help` 
 
 --------------------------------------------------------------------------------------------------------------------
 
@@ -242,9 +242,9 @@ Format: `cattag t/TAG [t/MORE_TAGS]…​ CATEGORY`
 * Only one category is allowed to be entered per command, i.e. `cattag t/tag1 acads t/tag2 general` is not allowed.
 
 Examples:
-* `cattag t/CS2100 acads` categorizes the tag `CS2100` under `Academics` and color of `t/CS2100` become `Gold`.
-* `cattag t/floorball t/mahjong activity` categorizes both tags `floorball` and `mahjong` under `Activities` with color `Blue`. 
-* Not-yet categorized tags have color `Grey` by default.
+* `cattag t/CS2100 acads` categorizes the tag `CS2100` under `Academics` and colour of `t/CS2100` become `Gold`.
+* `cattag t/floorball t/mahjong activity` categorizes both tags `floorball` and `mahjong` under `Activities` with colour `Blue`. 
+* Not-yet categorized tags have category `General` and colour `Grey` by default.
 
 ![cattag response image](images/cattagResponse.png)
 ### Undo a command : `undo`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,9 +242,9 @@ Format: `cattag t/TAG [t/MORE_TAGS]…​ CATEGORY`
 * Only one category is allowed to be entered per command, i.e. `cattag t/tag1 acads t/tag2 general` is not allowed.
 
 Examples:
-* `cattag t/CS2100 acads` categorizes the tag `CS2100` under `Academics` and colour of `t/CS2100` become `Gold`.
+* `cattag t/CS2100 acads` categorizes the tag `CS2100` under `Academics` and display colour of the tag`CS2100` becomes `Gold`.
 * `cattag t/floorball t/mahjong activity` categorizes both tags `floorball` and `mahjong` under `Activities` with colour `Blue`. 
-* Not-yet categorized tags have category `General` and colour `Grey` by default.
+* Newly created tags (by [`add`](#adding-a-person-add) or [`addtag`](#adds-tags-to-a-specific-person--addtag)) will have category `General` and colour `Grey` by default.
 
 ![cattag response image](images/cattagResponse.png)
 ### Undo a command : `undo`

--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -30,8 +30,8 @@
 * [User Guide]({{ baseUrl }}/UserGuide.html) :expanded:
   * [Quick Start]({{ baseUrl }}/UserGuide.html#quick-start)
   * [Features]({{ baseUrl }}/UserGuide.html#features)
+  * [Command Summary]({{ baseUrl }}/UserGuide.html#command-summary)
   * [FAQ]({{ baseUrl }}/UserGuide.html#faq)
-  * [Command Summary]({{ baseUrl }}/UserGuide.html#faq)
 * [Developer Guide]({{ baseUrl }}/DeveloperGuide.html) :expanded:
   * [Acknowledgements]({{ baseUrl }}/DeveloperGuide.html#acknowledgements)
   * [Setting Up]({{ baseUrl }}/DeveloperGuide.html#setting-up-getting-started)
@@ -40,10 +40,6 @@
   * [Documentation, logging, testing, configuration, dev-ops]({{ baseUrl }}/DeveloperGuide.html#documentation-logging-testing-configuration-dev-ops)
   * [Appendix: Requirements]({{ baseUrl }}/DeveloperGuide.html#appendix-requirements)
   * [Appendix: Instructions for manual testing]({{ baseUrl }}/DeveloperGuide.html#appendix-instructions-for-manual-testing)
-* Tutorials
-  * [Tracing code]({{ baseUrl }}/tutorials/TracingCode.html)
-  * [Adding a command]({{ baseUrl }}/tutorials/AddRemark.html)
-  * [Removing Fields]({{ baseUrl }}/tutorials/RemovingFields.html)
 * [About Us]({{ baseUrl }}/AboutUs.html)
       </site-nav>
     </div>

--- a/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CategorizeTagCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -29,7 +31,7 @@ public class CategorizeTagCommand extends Command {
     public static final String MESSAGE_TAG_NOT_EXIST = "Tag not found: %1$s";
     public static final String MESSAGE_INVALID_CATEGORY = "Invalid category: %1$s";
     public static final String MESSAGE_DUPLICATE_CATEGORY = "Current category of %s is already %s";
-    private final List<Tag> targetTags;
+    private final Set<Tag> targetTags;
     private final TagCategory updatedCategory;
 
     /**
@@ -38,7 +40,7 @@ public class CategorizeTagCommand extends Command {
     public CategorizeTagCommand(List<Tag> targetTags, TagCategory updatedCategory) {
         requireNonNull(targetTags);
         requireNonNull(updatedCategory);
-        this.targetTags = targetTags;
+        this.targetTags = new HashSet<>(targetTags);
         this.updatedCategory = updatedCategory;
     }
 
@@ -66,7 +68,7 @@ public class CategorizeTagCommand extends Command {
         return updatedCategory.equals(cat);
     }
 
-    private String formatTags(List<Tag> tags) {
+    private String formatTags(Set<Tag> tags) {
         String result = tags.toString();
         return result.substring(1, result.length() - 1);
     }


### PR DESCRIPTION
This should:
- Accept `cattag t/tag1 t/tag1 catA` as a valid command, and set `tag1` to `catA` successfully (if all other conditions are satisfied). Fixes #254 
- Add anchors to command summary table. Fixes #256 .