### PR TITLE
Remove traces of address book

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -143,8 +143,8 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [t/TAG]…​`
 * When editing tags, the existing tags of the person will be removed, i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
-* Do not add duplicate contacts to the list.
-  Two contacts are considered duplicates if they share the same name, email, or phone number.
+* After editing the person, there should be no duplicate contact in the campus connect.
+* Two contacts are considered duplicates if they share the same name, email, or phone number.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -118,6 +118,8 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL [t/TAG]…​`
 </box>
 
 * The phone number must follow the Singaporean convention: have 8 digits, start with 6, 8, or 9, and consist only of numbers.
+* Do not add duplicate contacts to the list.
+* Two contacts are considered duplicates if they share the same name, email, or phone number.
 
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com`
@@ -141,6 +143,8 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [t/TAG]…​`
 * When editing tags, the existing tags of the person will be removed, i.e. adding of tags is not cumulative.
 * You can remove all the person’s tags by typing `t/` without
     specifying any tags after it.
+* Do not add duplicate contacts to the list.
+  Two contacts are considered duplicates if they share the same name, email, or phone number.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -188,7 +188,7 @@ Examples:
 * `list` followed by `delete 2` deletes the 2nd person in CampusConnect.
 * `find n/Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
 
-### Adds tags to a specific person : `addtag`
+### Adding tags to a specific person : `addtag`
 
 Adds the specified person's tag.
 
@@ -259,6 +259,7 @@ Format: `undo`
 
 * Reverts the state of CampusConnect to the one before the most recent command, if any.
 * When the oldest version of CampusConnect is reached, `undo` command will cause an exception to be thrown
+* Only the command that modify the data of CampusConnect can be undone. Commands such as `list` and `find` will not be undone.
 
 ### Redo a command: `redo`
 
@@ -267,6 +268,7 @@ Reapplies a command that was previously undone by `undo`.
 Format: `redo`
 
 * Advances CampusConnect to the state it was in before the most recent `undo` command, if any.
+* Only the command that modify the data of CampusConnect can be redone. Commands such as `list` and `find` will not be redone.
 * Note: If a new command (excluding `redo` or `undo`) is executed after an `undo`, the redo history is cleared, and further `redo` will not be possible.
 
 ### Clearing all entries : `clear`

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -38,7 +38,7 @@ public interface Logic {
     ObservableList<Tag> getListOfCurrentTags();
 
     /**
-     * Returns the user prefs' address book file path.
+     * Returns the user prefs' campus connect file path.
      */
     Path getCampusConnectFilePath();
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -13,13 +13,13 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Adds a person to the address book.
+ * Adds a person to the campus connect.
  */
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the campus connect. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
@@ -33,7 +33,7 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the campus connect";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -6,7 +6,7 @@ import seedu.address.model.CampusConnect;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears the campus connect.
  */
 public class ClearCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -12,7 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Deletes a person identified using it's displayed index from the address book.
+ * Deletes a person identified using it's displayed index from the campus connect.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -27,7 +27,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Edits the details of an existing person in the address book.
+ * Edits the details of an existing person in the campus connect.
  */
 public class EditCommand extends Command {
 
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the campus connect.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Campus Connect as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -6,7 +6,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import seedu.address.model.Model;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all persons in the campus connect to the user.
  */
 public class ListCommand extends Command {
 

--- a/src/main/java/seedu/address/model/CampusConnect.java
+++ b/src/main/java/seedu/address/model/CampusConnect.java
@@ -126,7 +126,8 @@ public class CampusConnect implements ReadOnlyCampusConnect {
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the campus connect.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the campus connect.
+     * The person identity of {@code editedPerson} must not be the same as
+     * another existing person in the campus connect.
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);

--- a/src/main/java/seedu/address/model/CampusConnect.java
+++ b/src/main/java/seedu/address/model/CampusConnect.java
@@ -125,8 +125,8 @@ public class CampusConnect implements ReadOnlyCampusConnect {
 
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
-     * {@code target} must exist in the address book.
-     * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
+     * {@code target} must exist in the campus connect.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the campus connect.
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
@@ -136,7 +136,7 @@ public class CampusConnect implements ReadOnlyCampusConnect {
 
     /**
      * Removes {@code key} from this {@code CampusConnect}.
-     * {@code key} must exist in the address book.
+     * {@code key} must exist in the campus connect.
      */
     public void removePerson(Person key) {
         persons.remove(key);

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's email in the address book.
+ * Represents a Person's email in the CampusConnect.
  * Guarantees: immutable; is valid as declared in {@link #isValidEmail(String)}
  */
 public class Email {


### PR DESCRIPTION
Some messages displayed still use "address book".

I have changed all of these to "campus connect". 

We can correct our documentation at the last iteration.

Closes #259 