### PR TITLE
Fix FInd command with empty values

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTagCommand.java
@@ -51,7 +51,7 @@ public class DeleteTagCommand extends Command {
 
         Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
         assert personToEdit != null;
-        if (!personToEdit.hasTag(this.targetTag)) {
+        if (!personToEdit.hasTagWithValue(this.targetTag)) {
             throw new CommandException(Messages.MESSAGE_NO_TAG);
         }
 

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -16,7 +16,8 @@ public class EmailContainsKeywordsPredicate extends ContainsKeywordsPredicate {
     @Override
     public boolean test(Person person) {
         return super.getKeywords().stream()
-                .anyMatch(keyword -> person.getEmail().value.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(keyword -> !keyword.isEmpty()
+                        && person.getEmail().value.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -5,38 +5,53 @@ import java.util.List;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests if a {@code Person}'s {@code Email} matches any of the keywords given.
  */
 public class EmailContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
+    /**
+     * Constructs an {@code EmailContainsKeywordsPredicate} with the specified keywords.
+     * Each keyword is converted to lowercase to facilitate case-insensitive matching.
+     *
+     * @param keywords List of keywords to match against a person's email.
+     */
     public EmailContainsKeywordsPredicate(List<String> keywords) {
-        super(keywords);
+        // Normalizing keywords to lower case to optimize search
+        super(keywords.stream()
+                .filter(keyword -> keyword != null && !keyword.isEmpty())
+                .map(String::toLowerCase)
+                .toList());
     }
 
     @Override
     public boolean test(Person person) {
+        if (person == null || person.getEmail() == null) {
+            return false;
+        }
+
+        String email = person.getEmail().value.toLowerCase();
         return super.getKeywords().stream()
-                .anyMatch(keyword -> !keyword.isEmpty()
-                        && person.getEmail().value.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(email::contains);
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof EmailContainsKeywordsPredicate)) {
             return false;
         }
 
-        EmailContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (EmailContainsKeywordsPredicate) other;
-        return this.getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
+        EmailContainsKeywordsPredicate otherPredicate = (EmailContainsKeywordsPredicate) other;
+        return this.getKeywords().equals(otherPredicate.getKeywords());
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", this.getKeywords()).toString();
+        return new ToStringBuilder(this)
+                .add("keywords", this.getKeywords())
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -5,34 +5,48 @@ import java.util.List;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests if a {@code Person}'s {@code Name} matches any of the keywords provided.
  */
 public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
+    /**
+     * Constructs a {@code NameContainsKeywordsPredicate} with the specified keywords.
+     * Each keyword is converted to lowercase to facilitate case-insensitive matching.
+     *
+     * @param keywords List of keywords to match against a person's name.
+     */
     public NameContainsKeywordsPredicate(List<String> keywords) {
-        super(keywords);
+        // Normalizing keywords to lower case to optimize searches
+        super(keywords.stream()
+                .filter(keyword -> keyword != null && !keyword.isEmpty())
+                .map(String::toLowerCase)
+                .toList());
     }
 
     @Override
     public boolean test(Person person) {
-        return this.getKeywords().stream()
-                .anyMatch(keyword -> !keyword.isEmpty()
-                        && person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
+        if (person == null || person.getName() == null) {
+            return false;
+        }
+
+        String fullName = person.getName().fullName.toLowerCase();
+        return super.getKeywords().stream()
+                .anyMatch(fullName::contains);
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
 
-        // instanceof handles nulls
+        // Check for type compatibility
         if (!(other instanceof NameContainsKeywordsPredicate)) {
             return false;
         }
 
-        NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-        return this.getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
+        NameContainsKeywordsPredicate otherPredicate = (NameContainsKeywordsPredicate) other;
+        return this.getKeywords().equals(otherPredicate.getKeywords());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -16,7 +16,8 @@ public class NameContainsKeywordsPredicate extends ContainsKeywordsPredicate {
     @Override
     public boolean test(Person person) {
         return this.getKeywords().stream()
-                .anyMatch(keyword -> person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(keyword -> !keyword.isEmpty()
+                        && person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -110,9 +110,17 @@ public class Person {
     }
 
     /**
+     * Checks whether the person has any tags assigned to them.
+     * @return True if there is at least one tag assigned to them
+     */
+    public boolean hasTag() {
+        return !this.getTags().isEmpty();
+    }
+
+    /**
      * Checks whether the person has the tags with the same tag name.
      */
-    public boolean hasTag(Tag t) {
+    public boolean hasTagWithValue(Tag t) {
         return this.getTags().contains(t);
     }
 

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -5,34 +5,48 @@ import java.util.List;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests if a {@code Person}'s {@code Phone} number matches any of the keywords provided.
  */
 public class PhoneContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
+    /**
+     * Constructs a {@code PhoneContainsKeywordsPredicate} with the specified keywords.
+     * Each keyword is converted to lowercase to facilitate case-insensitive matching.
+     *
+     * @param keywords List of keywords to match against a person's phone number.
+     */
     public PhoneContainsKeywordsPredicate(List<String> keywords) {
-        super(keywords);
+        // Normalizing keywords to lower case to optimize searches
+        super(keywords.stream()
+                .filter(keyword -> keyword != null && !keyword.isEmpty())
+                .map(String::toLowerCase)
+                .toList());
     }
 
     @Override
     public boolean test(Person person) {
-        return this.getKeywords().stream()
-                .anyMatch(keyword -> !keyword.isEmpty()
-                        && person.getPhone().value.toLowerCase().contains(keyword.toLowerCase()));
+        if (person == null || person.getPhone() == null) {
+            return false;
+        }
+
+        String phoneNumber = person.getPhone().value.toLowerCase();
+        return super.getKeywords().stream()
+                .anyMatch(phoneNumber::contains);
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            return true;
+        if (this == other) {
+            return true; // Check if the same instance
         }
 
-        // instanceof handles nulls
+        // Check for type compatibility
         if (!(other instanceof PhoneContainsKeywordsPredicate)) {
             return false;
         }
 
-        PhoneContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (PhoneContainsKeywordsPredicate) other;
-        return this.getKeywords().equals(otherNameContainsKeywordsPredicate.getKeywords());
+        PhoneContainsKeywordsPredicate otherPredicate = (PhoneContainsKeywordsPredicate) other;
+        return this.getKeywords().equals(otherPredicate.getKeywords());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -16,7 +16,8 @@ public class PhoneContainsKeywordsPredicate extends ContainsKeywordsPredicate {
     @Override
     public boolean test(Person person) {
         return this.getKeywords().stream()
-                .anyMatch(keyword -> person.getPhone().value.toLowerCase().contains(keyword.toLowerCase()));
+                .anyMatch(keyword -> !keyword.isEmpty()
+                        && person.getPhone().value.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.commons.util.ToStringBuilder;
 
@@ -9,33 +10,55 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class TagContainsKeywordsPredicate extends ContainsKeywordsPredicate {
 
+    /**
+     * Constructs a {@code TagContainsKeywordsPredicate} with the given list of keywords.
+     * Each keyword is converted to lowercase to facilitate case-insensitive matching.
+     *
+     * @param keywords List of keywords to match against {@code Person}'s tags.
+     */
     public TagContainsKeywordsPredicate(List<String> keywords) {
-        super(keywords);
+        super(keywords.stream()
+                .map(String::toLowerCase)
+                .collect(Collectors.toList()));
     }
 
     @Override
     public boolean test(Person person) {
-        return this.getKeywords().stream()
-                .anyMatch(keyword -> person.getTags().toString().toLowerCase().contains(keyword.toLowerCase()));
+        return getKeywords().stream().anyMatch(keyword -> isKeywordPresentInPersonTags(keyword, person));
+    }
+
+    /**
+     * Checks if a given keyword is present in a person's tags.
+     * If the keyword is empty, it checks whether the person has no tags.
+     *
+     * @param keyword The keyword to search for in the person's tags.
+     * @param person The person whose tags are to be checked.
+     * @return True if the keyword is present in the person's tags
+     *     or if the keyword is empty and the person has no tags.
+     */
+    private boolean isKeywordPresentInPersonTags(String keyword, Person person) {
+        if (keyword.isEmpty()) {
+            return !person.hasTag();
+        }
+        return person.getTags().stream()
+                .map(tag -> tag.toString().toLowerCase())
+                .anyMatch(tag -> tag.contains(keyword));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
-
-        // instanceof handles nulls
         if (!(other instanceof TagContainsKeywordsPredicate)) {
             return false;
         }
-
-        TagContainsKeywordsPredicate otherTagContainsKeywordsPredicate = (TagContainsKeywordsPredicate) other;
-        return this.getKeywords().equals(otherTagContainsKeywordsPredicate.getKeywords());
+        TagContainsKeywordsPredicate that = (TagContainsKeywordsPredicate) other;
+        return this.getKeywords().equals(that.getKeywords());
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", this.getKeywords()).toString();
+        return new ToStringBuilder(this).add("keywords", getKeywords()).toString();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SuperFindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SuperFindCommandTest.java
@@ -1,2 +1,147 @@
-package seedu.address.logic.commands;public class SuperFindCommandTest {
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalCampusConnect;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.ContainsKeywordsPredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+
+public class SuperFindCommandTest {
+
+    private Model model;
+    private final String nameKeyword = "Alice";
+    private final String phoneKeyword = "94351253";
+    private final String tagKeyword = "Friend";
+    private final String emailKeyword = "alice@example.com";
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalCampusConnect(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validNameKeyword_success() {
+        ContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeyword));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyNameKeyword_success() {
+        ContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(Arrays.asList(""));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = SuperFindCommand.MESSAGE_NO_PERSONS_FOUND;
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validEmailKeyword_success() {
+        ContainsKeywordsPredicate predicate = new EmailContainsKeywordsPredicate(Arrays.asList(emailKeyword));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyEmailKeyword_success() {
+        ContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList(""));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = SuperFindCommand.MESSAGE_NO_PERSONS_FOUND;
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyPhoneKeyword_success() {
+        ContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Arrays.asList(""));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = SuperFindCommand.MESSAGE_NO_PERSONS_FOUND;
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        // should return no person
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validPhoneKeyword_success() {
+        ContainsKeywordsPredicate predicate = new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeyword));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validTagKeyword_success() {
+        ContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Arrays.asList(tagKeyword));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_emptyTagKeyword_success() {
+        ContainsKeywordsPredicate predicate = new TagContainsKeywordsPredicate(Arrays.asList(""));
+        SuperFindCommand command = new SuperFindCommand(predicate);
+
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        Model expectedModel = new ModelManager(model.getCampusConnect(), new UserPrefs());
+        expectedModel.updateFilteredPersonList(predicate);
+
+        // should only return Persons with no tag
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ContainsKeywordsPredicate predicateA = new NameContainsKeywordsPredicate(Arrays.asList(nameKeyword));
+        ContainsKeywordsPredicate predicateB = new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeyword));
+        SuperFindCommand commandA = new SuperFindCommand(predicateA);
+        SuperFindCommand commandB = new SuperFindCommand(predicateB);
+        SuperFindCommand commandC = new SuperFindCommand(predicateA);
+
+        assertTrue(commandA.equals(commandC));
+        assertFalse(commandA.equals(commandB));
+        assertFalse(commandA.equals(null));
+        assertFalse(commandA.equals(new Object()));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/SuperFindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SuperFindCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class SuperFindCommandTest {
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,11 +1,15 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,8 +17,10 @@ import seedu.address.logic.commands.SuperFindCommand;
 import seedu.address.model.person.CombinedContainsKeywordsPredicate;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.testutil.PersonBuilder;
 
 public class FindCommandParserTest {
 
@@ -90,5 +96,90 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " t/ \n PC2174ALecturer \n t/\t PC2032classmate  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_combinedArgs_returnsAppropriateFindCommand() {
+        NameContainsKeywordsPredicate namePredicate =
+                new NameContainsKeywordsPredicate(Arrays.asList("Alice"));
+        PhoneContainsKeywordsPredicate phonePredicate =
+                new PhoneContainsKeywordsPredicate(Arrays.asList("91234567"));
+        CombinedContainsKeywordsPredicate expectedPredicate =
+                new CombinedContainsKeywordsPredicate(List.of(namePredicate, phonePredicate));
+
+        SuperFindCommand expectedFindCommand = new SuperFindCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " n/Alice p/91234567", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_caseInsensitiveKeywords_success() {
+        // Sample persons
+        Person alice = new PersonBuilder().withName("ALICE").build();
+        Person bob = new PersonBuilder().withName("BOb").build();
+        Person charlie = new PersonBuilder().withName("ChaRLie").build();
+        List<Person> personList = Arrays.asList(alice, bob, charlie);
+
+        // Setting up case-insensitive predicates
+        NameContainsKeywordsPredicate namePredicate =
+                new NameContainsKeywordsPredicate(Arrays.asList("alice", "bob")); // Lowercase for input
+        CombinedContainsKeywordsPredicate expectedPredicate =
+                new CombinedContainsKeywordsPredicate(List.of(namePredicate));
+
+        SuperFindCommand expectedFindCommand = new SuperFindCommand(expectedPredicate);
+
+        // Filter using the predicate created from parsing
+        List<Person> filteredPersons = personList.stream()
+                .filter(expectedPredicate)
+                .collect(Collectors.toList());
+
+        // Assertions to confirm the output is correct
+        assertTrue(filteredPersons.contains(alice)); // Alice should be in the result
+        assertTrue(filteredPersons.contains(bob)); // Bob should be in the result
+        assertFalse(filteredPersons.contains(charlie)); // Charlie should not be in the result
+        assertEquals(2, filteredPersons.size()); // Expected size of filtered persons to be 2
+    }
+
+    @Test
+    public void parse_emptyPrefixBetweenValidones_validParse() {
+        Person alice = new PersonBuilder().withName("Alice").build();
+        Person bob = new PersonBuilder().withName("Bob").build();
+        Person charlie = new PersonBuilder().withName("Charlie").build();
+        List<Person> personList = Arrays.asList(alice, bob, charlie);
+
+        // Setting up the predicates
+        NameContainsKeywordsPredicate namePredicate =
+                new NameContainsKeywordsPredicate(Arrays.asList("Alice", "", "Bob"));
+        CombinedContainsKeywordsPredicate expectedPredicate =
+                new CombinedContainsKeywordsPredicate(List.of(namePredicate));
+
+        SuperFindCommand expectedFindCommand = new SuperFindCommand(expectedPredicate);
+
+        // Simulating parse success
+        assertParseSuccess(parser, " n/Alice n/ n/Bob", expectedFindCommand);
+
+        // Now verify that the predicate matches only the expected persons
+        List<Person> filteredPersons = personList.stream()
+                .filter(expectedPredicate)
+                .collect(Collectors.toList());
+
+        // Check if the filtered persons match the expected persons
+        assertTrue(filteredPersons.contains(alice));
+        assertTrue(filteredPersons.contains(bob));
+        assertFalse(filteredPersons.contains(charlie));
+        assertEquals(2, filteredPersons.size()); // expect only Alice and Bob to be present
+    }
+
+    @Test
+    public void parse_longInput_validParse() {
+        EmailContainsKeywordsPredicate emailPredicate =
+                new EmailContainsKeywordsPredicate(Arrays.asList("first@example.com", "second@example.com"));
+        CombinedContainsKeywordsPredicate expectedPredicate =
+                new CombinedContainsKeywordsPredicate(List.of(emailPredicate));
+
+        SuperFindCommand expectedFindCommand = new SuperFindCommand(expectedPredicate);
+
+        assertParseSuccess(parser, " e/"
+                + String.join(" e/", "first@example.com", "second@example.com"), expectedFindCommand);
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -149,10 +149,10 @@ public class PersonTest {
     }
 
     @Test
-    public void hasTag() {
+    public void hasTagWithValue() {
         Person aliceCopy = new PersonBuilder(ALICE).build();
-        assertTrue(aliceCopy.hasTag(new Tag("friends")));
-        assertFalse(aliceCopy.hasTag(new Tag("TEST")));
+        assertTrue(aliceCopy.hasTagWithValue(new Tag("friends")));
+        assertFalse(aliceCopy.hasTagWithValue(new Tag("TEST")));
     }
 
     @Test


### PR DESCRIPTION
This should:
- return empty list of persons when the input is empty for name, phone and email (e.d. find n/ )
- return persons with no tags when input is empty for tag (e.g. find t/ )
- add the relevant test cases to prove it works

Fixes #319 